### PR TITLE
[codex] Add multiple-choice answer generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ import { generateProblem, checkAnswer } from 'maths-game-problem-generator';
 // Generate a Year 3 division problem
 const problem = generateProblem({
   yearLevel: 'year3',
-  type: 'division'
+  type: 'division',
+  multipleChoice: true
 });
 
 console.log(problem.expression);      // e.g., "72 ÷ 8"
 console.log(problem.answer);          // e.g., 9
 console.log(problem.formattedAnswer); // e.g., "9"
+console.log(problem.choices);         // e.g., ["8", "9", "11", "12"]
 
 // Check a user's answer
 const isCorrect = checkAnswer(problem, 9);  // true
@@ -60,6 +62,13 @@ const year5Cube = generateProblem({ yearLevel: 'year5', type: 'cube' });
 | `formattedAnswer` | string | Answer as a display string (handles decimals cleanly) |
 | `type` | string | Problem type (e.g., `"addition"`, `"squared"`) |
 | `yearLevel` | string | Year level (e.g., `"year3"`) |
+
+When called with `{ multipleChoice: true }`, the returned object also includes:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `choices` | string[] | Plausible answer choices including the correct answer |
+| `correctChoice` | string | The correct answer as a display string |
 
 ### `checkAnswer(problem, userAnswer)`
 

--- a/index.js
+++ b/index.js
@@ -16,15 +16,19 @@ import {
  * @param {Object} options - Options for problem generation
  * @param {string} [options.yearLevel='reception'] - School year level (see YEAR_LEVELS for options)
  * @param {string} [options.type=null] - Optional problem type (see PROBLEM_TYPES for options)
+ * @param {boolean} [options.multipleChoice=false] - Include plausible multiple-choice answers
+ * @param {number} [options.choiceCount=4] - Number of answer choices to return when multipleChoice is true
  * @returns {Object} Math problem with expression and answer
  */
 function generateProblem(options = {}) {
     const yearLevel = options.yearLevel || 'reception';
     const type = options.type || null;
+    const multipleChoice = options.multipleChoice === true;
+    const choiceCount = Number.isInteger(options.choiceCount) ? Math.max(2, options.choiceCount) : 4;
 
     const problem = createMathProblem(yearLevel, type);
 
-    return {
+    const generatedProblem = {
         expression: problem.expression,
         expression_short: problem.expression_short,
         answer: problem.answer,
@@ -33,6 +37,159 @@ function generateProblem(options = {}) {
         type: problem.type || type || 'unknown',
         yearLevel: yearLevel
     };
+
+    if (!multipleChoice) {
+        return generatedProblem;
+    }
+
+    const choices = createMultipleChoiceAnswers(generatedProblem, { choiceCount });
+
+    return {
+        ...generatedProblem,
+        choices,
+        correctChoice: generatedProblem.formattedAnswer
+    };
+}
+
+/**
+ * Create plausible multiple-choice answer strings for a generated problem.
+ *
+ * Distractors favour nearby values, common operation slips, and scale-adjacent
+ * answers so they feel educationally plausible rather than arbitrary.
+ *
+ * @param {Object} problem - A problem returned by generateProblem
+ * @param {Object} options - Multiple-choice options
+ * @param {number} [options.choiceCount=4] - Number of choices to return
+ * @returns {Array<string>} Shuffled answer choices including the correct answer
+ */
+function createMultipleChoiceAnswers(problem, options = {}) {
+    const choiceCount = Number.isInteger(options.choiceCount) ? Math.max(2, options.choiceCount) : 4;
+    const correct = Number(problem.answer);
+    const formattedCorrect = problem.formattedAnswer ?? formatChoiceValue(correct);
+
+    const choices = new Map([[formattedCorrect, correct]]);
+    const candidates = buildDistractorCandidates(problem);
+
+    for (const candidate of candidates) {
+        addChoice(choices, candidate, correct);
+        if (choices.size >= choiceCount) {
+            break;
+        }
+    }
+
+    let fallbackStep = getFallbackStep(correct);
+    let direction = 1;
+    while (choices.size < choiceCount) {
+        const candidate = correct + fallbackStep * direction;
+        addChoice(choices, candidate, correct);
+        direction = direction > 0 ? -direction : -direction + 1;
+        if (direction === 0) {
+            direction = 1;
+            fallbackStep += getFallbackStep(correct);
+        }
+    }
+
+    return shuffleChoices([...choices.keys()]);
+}
+
+function buildDistractorCandidates(problem) {
+    const correct = Number(problem.answer);
+    const operands = extractNumbers(problem.expression);
+    const candidates = [];
+
+    candidates.push(...nearbyCandidates(correct, problem.yearLevel));
+
+    if (operands.length >= 2) {
+        const [a, b] = operands;
+        candidates.push(a + b, Math.abs(a - b), a * b);
+        if (b !== 0) {
+            candidates.push(a / b);
+        }
+        if (a !== 0) {
+            candidates.push(b / a);
+        }
+        candidates.push((a + 1) * b, a * (b + 1), Math.max(0, a - 1) * b, a * Math.max(0, b - 1));
+        candidates.push(a + b + 10, a + b - 10);
+    }
+
+    if (operands.length === 1) {
+        const [value] = operands;
+        candidates.push(value * 2, value + 2, value - 2, value * value, Math.sqrt(value));
+    }
+
+    candidates.push(correct * 10, correct / 10, correct + 10, correct - 10);
+    candidates.push(Math.round(correct), Math.floor(correct), Math.ceil(correct));
+
+    return candidates
+        .filter((value) => Number.isFinite(value))
+        .sort((a, b) => Math.abs(a - correct) - Math.abs(b - correct));
+}
+
+function nearbyCandidates(correct, yearLevel = 'reception') {
+    const magnitude = Math.max(1, Math.abs(correct));
+    const baseSteps = magnitude < 10 ? [1, 2, 3] : magnitude < 100 ? [1, 2, 5, 10] : [5, 10, 20, 50];
+    const decimalSteps = ['year5', 'year6'].includes(yearLevel) && !Number.isInteger(correct) ? [0.1, 0.2, 0.5, 1] : [];
+    const steps = [...decimalSteps, ...baseSteps];
+    return steps.flatMap((step) => [correct - step, correct + step]);
+}
+
+function extractNumbers(expression) {
+    return (expression.match(/[-+]?\d+(\.\d+)?/g) ?? []).map(Number);
+}
+
+function addChoice(choices, candidate, correct) {
+    if (!Number.isFinite(candidate)) {
+        return;
+    }
+
+    const normalizedCandidate = normalizeChoiceValue(candidate, correct);
+    const label = formatChoiceValue(normalizedCandidate);
+    if (label === formatChoiceValue(correct)) {
+        return;
+    }
+
+    choices.set(label, normalizedCandidate);
+}
+
+function normalizeChoiceValue(value, correct) {
+    if (Number.isInteger(correct)) {
+        return Math.round(value);
+    }
+
+    return Number(value.toFixed(2));
+}
+
+function formatChoiceValue(value) {
+    if (typeof value !== 'number') {
+        return String(value);
+    }
+    if (Number.isInteger(value)) {
+        return String(value);
+    }
+    return parseFloat(value.toFixed(10)).toString();
+}
+
+function getFallbackStep(correct) {
+    const magnitude = Math.max(1, Math.abs(correct));
+    if (!Number.isInteger(correct)) {
+        return magnitude < 10 ? 0.1 : 1;
+    }
+    if (magnitude < 10) {
+        return 1;
+    }
+    if (magnitude < 100) {
+        return 5;
+    }
+    return 10;
+}
+
+function shuffleChoices(choices) {
+    const shuffled = [...choices];
+    for (let index = shuffled.length - 1; index > 0; index -= 1) {
+        const swapIndex = Math.floor(Math.random() * (index + 1));
+        [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+    }
+    return shuffled;
 }
 
 /**
@@ -110,6 +267,7 @@ const PROBLEM_TYPES = getProblemTypes().reduce((acc, type) => {
 // Export the public API
 export {
     generateProblem,
+    createMultipleChoiceAnswers,
     checkAnswer,
     getYearLevels,
     getProblemTypes,
@@ -120,6 +278,7 @@ export {
 // Default export
 export default {
     generateProblem,
+    createMultipleChoiceAnswers,
     checkAnswer,
     getYearLevels,
     getProblemTypes,

--- a/test.js
+++ b/test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { generateProblem, createMultipleChoiceAnswers } from './index.js';
+
+const plainProblem = generateProblem({ yearLevel: 'year3', type: 'multiplication' });
+assert.equal(Array.isArray(plainProblem.choices), false);
+assert.equal('correctChoice' in plainProblem, false);
+
+const multipleChoiceProblem = generateProblem({
+    yearLevel: 'year3',
+    type: 'multiplication',
+    multipleChoice: true,
+    choiceCount: 4
+});
+
+assert.equal(multipleChoiceProblem.choices.length, 4);
+assert.equal(new Set(multipleChoiceProblem.choices).size, 4);
+assert.equal(multipleChoiceProblem.correctChoice, multipleChoiceProblem.formattedAnswer);
+assert.ok(multipleChoiceProblem.choices.includes(multipleChoiceProblem.correctChoice));
+
+const choices = createMultipleChoiceAnswers({
+    expression: '4 × 5',
+    answer: 20,
+    formattedAnswer: '20',
+    type: 'multiplication',
+    yearLevel: 'year3'
+}, { choiceCount: 4 });
+
+assert.equal(choices.length, 4);
+assert.equal(new Set(choices).size, 4);
+assert.ok(choices.includes('20'));
+assert.ok(choices.some((choice) => ['15', '19', '21', '25', '30'].includes(choice)));
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary

Adds backwards-compatible multiple-choice support to generateProblem() for game UIs that need plausible distractors.

## Changes

- Adds multipleChoice and choiceCount options to generateProblem().
- Keeps the existing expression, answer, formattedAnswer, type, and yearLevel fields unchanged.
- Adds choices and correctChoice only when multiple-choice mode is requested.
- Generates distractors from nearby values, operation slips, scale-adjacent answers, and year-aware decimal handling.
- Documents the new API and adds a Node assertion test.

## Validation

- npm test