### PR TITLE
[codex] Bump version for multiple-choice release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maths-game-problem-generator",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A JavaScript library for generating math problems tailored to different UK primary school year levels",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Summary: bump the package version to 1.1.0 now that the multiple-choice generator feature is merged.

Why: the new multiple-choice support is a backwards-compatible feature addition, so a minor version bump makes the package ready for an npm release.

Validation: npm test